### PR TITLE
Fix small bug preventing non-encrypted USM creation

### DIFF
--- a/wannacri/wannacri.py
+++ b/wannacri/wannacri.py
@@ -293,7 +293,7 @@ def create_usm():
 
     usm = Usm(video=[video], key=args.key)
     with open(filename + ".usm", "wb") as f:
-        mode = None if args.key is None else OpMode.ENCRYPT
+        mode = OpMode.NONE if args.key is None else OpMode.ENCRYPT
 
         for packet in usm.stream(mode, encoding=args.encoding):
             f.write(packet)


### PR DESCRIPTION
Just a minor issue that would cause "ValueError: Key is required for encryption/decryption." when creating USMs, with this change it seems to create them fine without needing a key.

(great project btw, looking forward to H264 creation support! In case you need a sample H264 USM to look at, https://zenhax.com/viewtopic.php?t=14969 has a link for one that uses the key 0x0000450D608C479F)