### PR TITLE
Add experimental HCA encoding support

### DIFF
--- a/wannacri/usm/__init__.py
+++ b/wannacri/usm/__init__.py
@@ -12,7 +12,7 @@ from .tools import (
 from .page import UsmPage, get_pages, pack_pages
 from .usm import Usm
 from .chunk import UsmChunk
-from .media import UsmMedia, UsmVideo, UsmAudio, GenericVideo, GenericAudio, Vp9, H264
+from .media import UsmMedia, UsmVideo, UsmAudio, GenericVideo, GenericAudio, Vp9, H264, HCA
 from .types import OpMode, ElementOccurrence, ElementType, PayloadType, ChunkType
 
 import logging

--- a/wannacri/usm/media/__init__.py
+++ b/wannacri/usm/media/__init__.py
@@ -1,6 +1,6 @@
 from .protocols import UsmVideo, UsmAudio, UsmMedia
 from .video import GenericVideo, Vp9, H264
-from .audio import GenericAudio
+from .audio import GenericAudio, HCA
 from .tools import (
     create_video_crid_page,
     create_video_header_page,

--- a/wannacri/usm/media/audio.py
+++ b/wannacri/usm/media/audio.py
@@ -1,7 +1,13 @@
-from typing import Generator, Optional, List
-
+import os.path
+import typing
+from typing import Generator, Optional, List, Any
+import struct
 from .protocols import UsmAudio
 from ..page import UsmPage
+from collections import OrderedDict
+from .tools import create_audio_header_page, create_audio_crid_page, AUDIO_CODEC
+from pathlib import Path
+import math
 
 
 class GenericAudio(UsmAudio):
@@ -24,3 +30,154 @@ class GenericAudio(UsmAudio):
         self._length = length
         self._channel_number = channel_number
         self._metadata_pages = metadata_pages
+
+
+class HCA(UsmAudio):
+    def __init__(
+            self,
+            filepath: str,
+            channel_number: int = 1,
+            format_version: int = 0
+    ):
+
+        metadata = self._get_metadata(filepath)
+        # have no idea how this is done, pure guess based on minbuf guess elsewhere
+        minbuf = math.ceil(metadata["CompHeader"]["FrameSize"][0] * 54.4140625)
+        # Estimated comparing video fps to audio fps, avg bitrate
+        # Framesize bit is sort of extrapolated from that
+        avbps = round(0.0399607 * metadata["FormatHeader"]["FrameCount"][0] * metadata["CompHeader"]["FrameSize"][0])
+
+        self._crid_page = create_audio_crid_page(
+            Path(filepath).name,
+            os.path.getsize(filepath),
+            format_version,
+            metadata["FormatHeader"]["ChannelCount"][0],
+            minbuf,
+            avbps
+        )
+
+        self._header_page = create_audio_header_page(
+            AUDIO_CODEC.HCA,
+            metadata["FormatHeader"]["SampleRate"][0],
+            metadata["FormatHeader"]["ChannelCount"][0],
+            1,  # There should be only one metadata page for HCA
+            256,  # HCA metadata is always 256 long I think?
+            27860,  # I have no idea
+        )
+
+        def packet_gen(
+            path: str
+        ) -> Generator[typing.Tuple[bytes, bool], None, None]:
+            video = open(path, "rb")
+            yield video.read(96)
+            for i in range(metadata["FormatHeader"]["FrameCount"][0]):
+                yield video.read(metadata["CompHeader"]["FrameSize"][0])
+            video.close()
+
+        self._stream = packet_gen(filepath)
+        self._length = metadata["FormatHeader"]["FrameCount"][0] + 1
+        self._channel_number = metadata["FormatHeader"]["ChannelCount"][0]
+        self._metadata_pages = None
+
+    def _get_metadata(self, filepath: str):
+        metadata_blocks = [HCAHeader, FormatHeader, CompHeader]
+        metadata = {}
+        seek = 0
+        with open(filepath, "rb") as f:
+            while metadata_blocks:
+                block_id = self._get_metadata_chunk_id(f)
+                f.seek(seek)
+                for block in metadata_blocks:
+                    if block.ID == block_id:
+                        data = f.read(block.size())
+                        metadata[block.__name__] = block.unpack(data)
+                        seek += block.size()
+                        metadata_blocks.remove(block)
+                        break
+        return metadata
+
+    def _get_metadata_chunk_id(self, file: typing.IO):
+        format_string = ">cccc"
+        size = struct.calcsize(format_string)
+        data = struct.unpack(format_string, file.read(size))
+        return b"".join(data)
+
+
+class ClassStruct:
+    FORMAT: OrderedDict = OrderedDict()
+    CONVERT_TYPES = {}
+    @classmethod
+    def unpack(cls, string: bytes) -> dict:
+        values = {}
+        start = 0
+        for key, value in cls.FORMAT.items():
+            size = struct.calcsize(value)
+            values[key] = struct.unpack(value, string[start: start+size])
+            start += size
+        for key, value in cls.CONVERT_TYPES.items():
+            data = bytearray(b"".join(values[key]))
+            # doesn't take endianness into account, could break things
+            while len(data) % 4 != 0:
+                data.insert(0, 0)
+            values[key] = struct.unpack(value, data)
+        return values
+
+    @classmethod
+    def pack(cls, values: dict) -> bytes:
+        byte_values = []
+        for key, value in cls.FORMAT.items():
+            try:
+                data = values[key]
+            except KeyError:
+                raise Exception(f"Key {key} missing in pack dictionary")
+            byte_values.append(struct.pack(value, data))
+        return b"".join(byte_values)
+
+    @classmethod
+    def size(cls):
+        return sum([struct.calcsize(value) for value in cls.FORMAT.values()])
+
+
+
+class HCAHeader(ClassStruct):
+    ID = b'HCA\x00'
+    FORMAT = OrderedDict((
+        ("Signature", ">cccc"),
+        ("VersionMajor", ">B"),
+        ("VersionMinor", ">B"),
+        ("HeaderSize", ">H"),
+    ))
+
+
+# Only unpacks, does not pack correctly
+class FormatHeader(ClassStruct):
+    ID = b'fmt\x00'
+    FORMAT = OrderedDict((
+        ("Signature", ">cccc"),
+        ("ChannelCount", ">c"), # 8 bit integer
+        ("SampleRate", ">ccc"), # 24 bit integer
+        ("FrameCount", ">I"),
+        ("InsertedSamples", ">H"),
+        ("AppendedSamples", ">H"),
+    ))
+    CONVERT_TYPES = {
+        "ChannelCount": ">I",
+        "SampleRate": ">I"
+    }
+
+class CompHeader(ClassStruct):
+    ID = b"comp"
+    FORMAT = OrderedDict((
+        ("Signature", ">cccc"),
+        ("FrameSize", ">H"),
+        ("MinResolution", ">b"),
+        ("MaxResolution", ">b"),
+        ("TrackCount", ">b"),
+        ("ChannelConfig", ">b"),
+        ("TotalBandCount", ">B"),
+        ("BaseBandCount", ">B"),
+        ("StereoBandCount", ">B"),
+        ("BandsPerHfrGroup", ">B"),
+        ("reserved1", ">b"),
+        ("reserved2", ">b"),
+    ))

--- a/wannacri/usm/media/tools.py
+++ b/wannacri/usm/media/tools.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import List
 
 from ..page import UsmPage
@@ -57,4 +58,49 @@ def create_video_header_page(
     header.update("max_picture_size", ElementType.INT, 0)
     header.update("color_space", ElementType.INT, 0)
     header.update("picture_type", ElementType.INT, 0)
+    return header
+
+
+def create_audio_crid_page(
+    filename: str,
+    filesize: int,
+    format_version: int,
+    channel_number: int,
+    minbuf: int,
+    avbps: int
+) -> UsmPage:
+    crid = UsmPage("CRIUSF_DIR_STREAM")
+    crid.update("fmtver", ElementType.INT, format_version)
+    crid.update("filename", ElementType.STRING, filename)
+    crid.update("filesize", ElementType.INT, filesize)
+    crid.update("datasize", ElementType.INT, 0)
+    crid.update("stmid", ElementType.INT, 1079199297)  # @SFA
+    crid.update("chno", ElementType.SHORT, channel_number)
+    crid.update("minchk", ElementType.SHORT, 1)
+    crid.update("minbuf", ElementType.INT, minbuf)
+    crid.update("avbps", ElementType.INT, avbps)
+    return crid
+
+
+class AUDIO_CODEC(Enum):
+    HCA = 4
+
+
+def create_audio_header_page(
+    audio_codec: AUDIO_CODEC,
+    sampling_rate: int,
+    num_channels: int,
+    metadata_count: int,
+    metadata_size: int,
+    ixsize: int,
+    ambisonics: int = 0  # I have no idea, disabled?
+) -> UsmPage:
+    header = UsmPage("AUDIO_HDRINFO")
+    header.update("audio_codec", ElementType.CHAR, audio_codec.value)
+    header.update("sampling_rate", ElementType.INT, sampling_rate)
+    header.update("num_channels", ElementType.INT, num_channels)
+    header.update("metadata_count", ElementType.INT, metadata_count)
+    header.update("metadata_size", ElementType.INT, metadata_size)
+    header.update("ixsize", ElementType.INT, ixsize)
+    header.update("ambisonics", ElementType.CHAR, ambisonics)    # IDK what this is
     return header

--- a/wannacri/wannacri.py
+++ b/wannacri/wannacri.py
@@ -14,7 +14,7 @@ from pythonjsonlogger import jsonlogger
 
 import wannacri
 from .codec import Sofdec2Codec
-from .usm import is_usm, Usm, Vp9, H264, OpMode, generate_keys
+from .usm import is_usm, Usm, Vp9, H264, HCA, OpMode, generate_keys
 
 
 def create_usm():
@@ -31,6 +31,14 @@ def create_usm():
         metavar="input file path",
         type=existing_file,
         help="Path to video file.",
+    )
+    parser.add_argument(
+        "-a",
+        "--input_audio",
+        metavar="input audio file path",
+        type=existing_file,
+        default=None,
+        help="Path to audio file.",
     )
     parser.add_argument(
         "-e",
@@ -68,9 +76,13 @@ def create_usm():
     else:
         raise NotImplementedError("Non-Vp9/H.264 files are not yet implemented.")
 
+    audios = None
+    if args.input_audio:
+        audios = [HCA(args.input_audio)]
+
     filename = os.path.splitext(args.input)[0]
 
-    usm = Usm(videos=[video], key=args.key)
+    usm = Usm(videos=[video], audios=audios, key=args.key)
     with open(filename + ".usm", "wb") as f:
         mode = OpMode.NONE if args.key is None else OpMode.ENCRYPT
 


### PR DESCRIPTION
Tried adding support for HCA to re-encode videos for the PC release of Chaos;Head NOAH. Used the VGAudio binary template as a reference for how the HCA file works as well as some USM files I had on hand.

I can't check if this works because the game actually uses mpeg1 instead of H264, which I didn't fully realize until after I finished this lol. It seems like the only info online indicates USM is only used with H264/VP9, have you maybe seen this before in another game?

Thanks for the library anyways though!